### PR TITLE
Implement no_std support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,9 +25,9 @@ environment:
       RUST_VERSION: nightly
 
     - TARGET: i686-pc-windows-gnu
-      RUST_VERSION: 1.0.0
+      RUST_VERSION: 1.8.0
     - TARGET: x86_64-pc-windows-gnu
-      RUST_VERSION: 1.0.0
+      RUST_VERSION: 1.8.0
 
 install:
   - ps: >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ rust:
   - nightly
   - beta
   - stable
-  # and the first stable one (this should be bumped as the minimum
+  # and the first supported stable one (this should be bumped as the minimum
   # Rust version required changes)
-  - 1.0.0
+  - 1.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - re-licensed under "MIT/Apache-2.0"
+- support `no_std`, requiring at least Rust 1.8
 
 ## [0.1.2] - 2017-01-09
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,18 @@
 [package]
-name = "quadrature"
-version = "0.1.2"
 authors = ["Jacob Finkelman <Eh2406@wayne.edu>"]
 description = "This provides several fast numerical integration methods. This library is pure safe rust, and cross-platform. The double exponential algorithm is naturally adaptive, and does not allocate."
-repository = "https://github.com/Eh2406/quadrature"
-readme = "README.md"
 documentation = "https://docs.rs/quadrature/"
 keywords = ["math", "mathematics", "numerics"]
 license = "BSD-2-Clause"
+name = "quadrature"
+readme = "README.md"
+repository = "https://github.com/Eh2406/quadrature"
+version = "0.1.2"
 
 [dependencies]
+num-traits = "0.1.42"
+
+[profile]
 
 [profile.bench]
 debug = true

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ The clenshaw curtis algorithm exactly integrates polynomials of order N. This im
 
 Testing
 ----
-I have been testing against `rust 1.0` with:
+I have been testing against `rust 1.8` with:
 ```cmd
-> rustup override set 1.0.0
+> rustup override set 1.8.0
 > cargo test
 > rustup override set nightly
 > cargo test

--- a/src/clenshaw_curtis/constants.rs
+++ b/src/clenshaw_curtis/constants.rs
@@ -402,7 +402,7 @@ mod tests {
     fn total_weights() {
         for &w in WEIGHTS.iter() {
             let s = 2.0 * w.iter().fold(0.0, |sum, x| sum + x) - w[0];
-            println! {"{:#?}", s};
+            //println! {"{:#?}", s};
             assert!((s - 2.0).abs() <= 1e-13);
         }
     }

--- a/src/clenshaw_curtis/mod.rs
+++ b/src/clenshaw_curtis/mod.rs
@@ -78,17 +78,3 @@ fn integrate_core<F>(f: F, target_absolute_error: f64) -> Output
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    unit_test!(trivial_function_works = |_| 0.5; -1.0..1.0; 1e-14);
-    unit_test!(demo_function1_works = |x| (-x / 5.0).exp() * x.powf(-1.0 / 3.0); 0.0..10.0; 1e-6 => 3.6798142583691758; 257);
-    unit_test!(demo_function2_works = |x| (1.0 - x).powf(5.0) * x.powf(-1.0 / 3.0); 0.0..1.0; 1e-6 => 0.41768525592055004; 257);
-    unit_test!(demo_function3_works = |x| (-x / 5000.0).exp() * (x / 1000.0).powf(-1.0 / 3.0); 0.0..10000.0; 1e-6 => 3679.81425836918; 257);
-    unit_test!(demo_bad_function1_works = |x| (1.0 - x).powf(0.99); 0.0..1.0; 1e-6 => 0.50251256281407035);
-    unit_test!(demo_bad_function2_works = |x| x.abs(); -1.0..1.0; 1e-6 => 1.0; 257);
-    unit_test!(demo_bad_function3_works = |x| (0.5 - x.abs()).abs(); -1.0..1.0; 1e-6 => 0.5; 257);
-    unit_test!(demo_circle = |x| ((1.0-(x.powi(2))).sqrt()).abs(); -1.0..1.0; 1e-6 => 1.5707963267949);
-    unit_test!(demo_bad_circle = |x| ((1.0-(x.powi(2))).sqrt()-0.7).abs(); -1.0..1.0; 1e-4 => 0.420201353577392);
-}

--- a/src/clenshaw_curtis/mod.rs
+++ b/src/clenshaw_curtis/mod.rs
@@ -3,6 +3,8 @@
 //! It also does not allocate on the heap, however it does use a `[f64; 129]` to store the function values. It has a hard coded maximum of approximately 257 function evaluations. This guarantees that the algorithm will return.
 //! The clenshaw curtis algorithm exactly integrates polynomials of order N. This implementation starts with an N of approximately 5 and increases up to an N of approximately 257. In general the error in the algorithm decreases exponentially in the number of function evaluations. In summery clenshaw curtis will in general use **more stack space** and **run slower** than the double exponential algorithm, unless clenshaw curtis can get the exact solution.
 
+use core::f64;
+
 mod constants;
 
 use self::constants::*;
@@ -45,13 +47,13 @@ pub fn integrate<F>(f: F, a: f64, b: f64, target_absolute_error: f64) -> Output
 fn integrate_core<F>(f: F, target_absolute_error: f64) -> Output
     where F: Fn(f64) -> f64
 {
-    let mut f_value = [::std::f64::NAN; 129];
+    let mut f_value = [::core::f64::NAN; 129];
     debug_assert_eq!(f_value.len(), ABCISSAS.len());
     let mut max_x_idx = 1;
     f_value[0] = f(0.0);
 
-    let mut error_estimate = ::std::f64::MAX;
-    let mut integral = ::std::f64::MAX;
+    let mut error_estimate = ::core::f64::MAX;
+    let mut integral = ::core::f64::MAX;
     for &w in WEIGHTS.iter() {
         for (v, &x) in f_value[max_x_idx..w.len()]
             .iter_mut()

--- a/src/double_exponential/mod.rs
+++ b/src/double_exponential/mod.rs
@@ -104,18 +104,3 @@ fn integrate_core<F>(f: F, target_absolute_error: f64) -> Output
         integral: integral,
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    unit_test!(trivial_function_works = |_| 0.5; -1.0..1.0; 1e-14);
-    unit_test!(demo_function1_works = |x| (-x / 5.0).exp() * x.powf(-1.0 / 3.0); 0.0..10.0; 1e-6 => 3.6798142583691758);
-    unit_test!(demo_function2_works = |x| (1.0 - x).powf(5.0) * x.powf(-1.0 / 3.0); 0.0..1.0; 1e-6 => 0.41768525592055004);
-    unit_test!(demo_function3_works = |x| (-x / 5000.0).exp() * (x / 1000.0).powf(-1.0 / 3.0); 0.0..10000.0; 1e-6);
-    unit_test!(demo_bad_function1_works = |x| (1.0 - x).powf(0.99); 0.0..1.0; 1e-6 => 0.50251256281407035);
-    unit_test!(demo_bad_function2_works = |x| x.abs(); -1.0..1.0; 1e-6 => 1.0; 385);
-    unit_test!(demo_bad_function3_works = |x| (0.5 - x.abs()).abs(); -1.0..1.0; 1e-6 => 0.5; 385);
-    unit_test!(demo_circle = |x| ((1.0-(x.powi(2))).sqrt()).abs(); -1.0..1.0; 1e-6 => 1.5707963267949);
-    unit_test!(demo_bad_circle = |x| ((1.0-(x.powi(2))).sqrt()-0.7).abs(); -1.0..1.0; 1e-4 => 0.420201353577392);
-}

--- a/src/double_exponential/mod.rs
+++ b/src/double_exponential/mod.rs
@@ -47,11 +47,11 @@ pub fn integrate<F>(f: F, a: f64, b: f64, target_absolute_error: f64) -> Output
 fn integrate_core<F>(f: F, target_absolute_error: f64) -> Output
     where F: Fn(f64) -> f64
 {
-    let mut error_estimate = ::std::f64::MAX;
+    let mut error_estimate = ::core::f64::MAX;
     let mut num_function_evaluations = 1;
-    let mut current_delta = ::std::f64::MAX;
+    let mut current_delta = ::core::f64::MAX;
 
-    let mut integral = 2.0 * ::std::f64::consts::FRAC_PI_2 * f(0.0);
+    let mut integral = 2.0 * ::core::f64::consts::FRAC_PI_2 * f(0.0);
 
     for &weight in &WEIGHTS {
         let new_contribution = weight.iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,6 @@
 
 extern crate num_traits;
 
-#[macro_use]
-#[cfg(test)]
-mod test_macro;
-
 pub mod double_exponential;
 pub mod clenshaw_curtis;
 mod traits;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@
 //! It is a port of the [Fast Numerical Integration](https://www.codeproject.com/kb/recipes/fastnumericalintegration.aspx) from c++ to rust. The original code is by John D. Cook, and is licensed under the BSD.
 //!
 //! Other Algorithms are provided in modules.
+#![no_std]
+
+extern crate num_traits;
 
 #[macro_use]
 #[cfg(test)]
@@ -9,6 +12,7 @@ mod test_macro;
 
 pub mod double_exponential;
 pub mod clenshaw_curtis;
+mod traits;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Output {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,3 +1,6 @@
+// Parts of this code were taken from the Rust core library, distributed under
+// the terms of both the MIT license and the Apache License (Version 2.0).
+
 use core::ops::Neg;
 
 use num_traits::Num;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,198 @@
+use core::mem;
+use core::num::FpCategory;
+use core::ops::Neg;
+
+use num_traits::Num;
+
+/// Basic floating point operations that work with `core`.
+pub trait BasicFloat: Num + Neg<Output = Self> + PartialOrd + Copy {
+    /// Returns positive infinity.
+    #[inline]
+    fn infinity() -> Self;
+
+    /// Returns negative infinity.
+    #[inline]
+    fn neg_infinity() -> Self;
+
+    /// Returns NaN.
+    #[inline]
+    fn nan() -> Self;
+
+    /// Returns `true` if the number is NaN.
+    #[inline]
+    fn is_nan(self) -> bool {
+        self != self
+    }
+
+    /// Returns `true` if the number is infinite.
+    #[inline]
+    fn is_infinite(self) -> bool {
+        self == Self::infinity() || self == Self::neg_infinity()
+    }
+
+    /// Returns `true` if the number is neither infinite or NaN.
+    #[inline]
+    fn is_finite(self) -> bool {
+        !(self.is_nan() || self.is_infinite())
+    }
+
+    /// Returns `true` if the number is neither zero, infinite, subnormal or NaN.
+    #[inline]
+    fn is_normal(self) -> bool {
+        self.classify() == FpCategory::Normal
+    }
+
+    /// Returns the floating point category of the number. If only one property
+    /// is going to be tested, it is generally faster to use the specific
+    /// predicate instead.
+    #[inline]
+    fn classify(self) -> FpCategory;
+
+    /// Computes the absolute value of `self`. Returns `BasicFloat::nan()` if the
+    /// number is `BasicFloat::nan()`.
+    #[inline]
+    fn abs(self) -> Self {
+        if self.is_sign_positive() {
+            return self;
+        }
+        if self.is_sign_negative() {
+            return -self;
+        }
+        Self::nan()
+    }
+
+    /// Returns a number that represents the sign of `self`.
+    ///
+    /// - `1.0` if the number is positive, `+0.0` or `BasicFloat::infinity()`
+    /// - `-1.0` if the number is negative, `-0.0` or `BasicFloat::neg_infinity()`
+    /// - `BasicFloat::nan()` if the number is `BasicFloat::nan()`
+    #[inline]
+    fn signum(self) -> Self {
+        if self.is_sign_positive() {
+            return Self::one();
+        }
+        if self.is_sign_negative() {
+            return -Self::one();
+        }
+        Self::nan()
+    }
+
+    /// Returns `true` if `self` is positive, including `+0.0` and
+    /// `BasicFloat::infinity()`.
+    #[inline]
+    fn is_sign_positive(self) -> bool {
+        self > Self::zero() || (Self::one() / self) == Self::infinity()
+    }
+
+    /// Returns `true` if `self` is negative, including `-0.0` and
+    /// `BasicFloat::neg_infinity()`.
+    #[inline]
+    fn is_sign_negative(self) -> bool {
+        self < Self::zero() || (Self::one() / self) == Self::neg_infinity()
+    }
+
+    /// Returns the reciprocal (multiplicative inverse) of the number.
+    #[inline]
+    fn recip(self) -> Self {
+        Self::one() / self
+    }
+
+    #[inline]
+    fn powi(self, mut exp: i32) -> Self {
+        if exp == 0 { return Self::one() }
+
+        let mut base;
+        if exp < 0 {
+            exp = -exp;
+            base = self.recip();
+        } else {
+            base = self;
+        }
+
+        while exp & 1 == 0 {
+            base = base * base;
+            exp >>= 1;
+        }
+        if exp == 1 { return base }
+
+        let mut acc = base;
+        while exp > 1 {
+            exp >>= 1;
+            base = base * base;
+            if exp & 1 == 1 {
+                acc = acc * base;
+            }
+        }
+        acc
+    }
+
+    /// Converts to degrees, assuming the number is in radians.
+    #[inline]
+    fn to_degrees(self) -> Self;
+
+    /// Converts to radians, assuming the number is in degrees.
+    #[inline]
+    fn to_radians(self) -> Self;
+}
+
+impl BasicFloat for f32 {
+    fn infinity() -> Self {
+        ::core::f32::INFINITY
+    }
+    fn neg_infinity() -> Self {
+        ::core::f32::INFINITY
+    }
+    fn nan() -> Self {
+        ::core::f32::NAN
+    }
+    fn classify(self) -> FpCategory {
+        const EXP_MASK: u32 = 0x7f800000;
+        const MAN_MASK: u32 = 0x007fffff;
+
+        let bits: u32 = unsafe { mem::transmute(self) };
+        match (bits & MAN_MASK, bits & EXP_MASK) {
+            (0, 0) => FpCategory::Zero,
+            (_, 0) => FpCategory::Subnormal,
+            (0, EXP_MASK) => FpCategory::Infinite,
+            (_, EXP_MASK) => FpCategory::Nan,
+            _ => FpCategory::Normal,
+        }
+    }
+    fn to_degrees(self) -> Self {
+        self * (180.0 / ::core::f32::consts::PI)
+    }
+    fn to_radians(self) -> Self {
+        self * (::core::f32::consts::PI / 180.0)
+    }
+}
+
+impl BasicFloat for f64 {
+    fn infinity() -> Self {
+        ::core::f64::INFINITY
+    }
+    fn neg_infinity() -> Self {
+        ::core::f64::INFINITY
+    }
+    fn nan() -> Self {
+        ::core::f64::NAN
+    }
+    fn classify(self) -> FpCategory {
+        const EXP_MASK: u64 = 0x7ff0000000000000;
+        const MAN_MASK: u64 = 0x000fffffffffffff;
+
+        let bits: u64 = unsafe { mem::transmute(self) };
+        match (bits & MAN_MASK, bits & EXP_MASK) {
+            (0, 0) => FpCategory::Zero,
+            (_, 0) => FpCategory::Subnormal,
+            (0, EXP_MASK) => FpCategory::Infinite,
+            (_, EXP_MASK) => FpCategory::Nan,
+            _ => FpCategory::Normal,
+        }
+    }
+    fn to_degrees(self) -> Self {
+        self * (180.0 / ::core::f64::consts::PI)
+    }
+    fn to_radians(self) -> Self {
+        self * (::core::f64::consts::PI / 180.0)
+    }
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,3 @@
-use core::mem;
-use core::num::FpCategory;
 use core::ops::Neg;
 
 use num_traits::Num;
@@ -35,18 +33,6 @@ pub trait BasicFloat: Num + Neg<Output = Self> + PartialOrd + Copy {
     fn is_finite(self) -> bool {
         !(self.is_nan() || self.is_infinite())
     }
-
-    /// Returns `true` if the number is neither zero, infinite, subnormal or NaN.
-    #[inline]
-    fn is_normal(self) -> bool {
-        self.classify() == FpCategory::Normal
-    }
-
-    /// Returns the floating point category of the number. If only one property
-    /// is going to be tested, it is generally faster to use the specific
-    /// predicate instead.
-    #[inline]
-    fn classify(self) -> FpCategory;
 
     /// Computes the absolute value of `self`. Returns `BasicFloat::nan()` if the
     /// number is `BasicFloat::nan()`.
@@ -125,14 +111,6 @@ pub trait BasicFloat: Num + Neg<Output = Self> + PartialOrd + Copy {
         }
         acc
     }
-
-    /// Converts to degrees, assuming the number is in radians.
-    #[inline]
-    fn to_degrees(self) -> Self;
-
-    /// Converts to radians, assuming the number is in degrees.
-    #[inline]
-    fn to_radians(self) -> Self;
 }
 
 impl BasicFloat for f32 {
@@ -145,25 +123,6 @@ impl BasicFloat for f32 {
     fn nan() -> Self {
         ::core::f32::NAN
     }
-    fn classify(self) -> FpCategory {
-        const EXP_MASK: u32 = 0x7f800000;
-        const MAN_MASK: u32 = 0x007fffff;
-
-        let bits: u32 = unsafe { mem::transmute(self) };
-        match (bits & MAN_MASK, bits & EXP_MASK) {
-            (0, 0) => FpCategory::Zero,
-            (_, 0) => FpCategory::Subnormal,
-            (0, EXP_MASK) => FpCategory::Infinite,
-            (_, EXP_MASK) => FpCategory::Nan,
-            _ => FpCategory::Normal,
-        }
-    }
-    fn to_degrees(self) -> Self {
-        self * (180.0 / ::core::f32::consts::PI)
-    }
-    fn to_radians(self) -> Self {
-        self * (::core::f32::consts::PI / 180.0)
-    }
 }
 
 impl BasicFloat for f64 {
@@ -175,24 +134,5 @@ impl BasicFloat for f64 {
     }
     fn nan() -> Self {
         ::core::f64::NAN
-    }
-    fn classify(self) -> FpCategory {
-        const EXP_MASK: u64 = 0x7ff0000000000000;
-        const MAN_MASK: u64 = 0x000fffffffffffff;
-
-        let bits: u64 = unsafe { mem::transmute(self) };
-        match (bits & MAN_MASK, bits & EXP_MASK) {
-            (0, 0) => FpCategory::Zero,
-            (_, 0) => FpCategory::Subnormal,
-            (0, EXP_MASK) => FpCategory::Infinite,
-            (_, EXP_MASK) => FpCategory::Nan,
-            _ => FpCategory::Normal,
-        }
-    }
-    fn to_degrees(self) -> Self {
-        self * (180.0 / ::core::f64::consts::PI)
-    }
-    fn to_radians(self) -> Self {
-        self * (::core::f64::consts::PI / 180.0)
     }
 }

--- a/tests/clenshaw_curtis.rs
+++ b/tests/clenshaw_curtis.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 extern crate quadrature;
 
 use quadrature::clenshaw_curtis::integrate;

--- a/tests/clenshaw_curtis.rs
+++ b/tests/clenshaw_curtis.rs
@@ -1,0 +1,16 @@
+extern crate quadrature;
+
+use quadrature::clenshaw_curtis::integrate;
+
+#[macro_use]
+mod test_macro;
+
+unit_test!(trivial_function_works = |_| 0.5; -1.0..1.0; 1e-14);
+unit_test!(demo_function1_works = |x| (-x / 5.0).exp() * x.powf(-1.0 / 3.0); 0.0..10.0; 1e-6 => 3.6798142583691758; 257);
+unit_test!(demo_function2_works = |x| (1.0 - x).powf(5.0) * x.powf(-1.0 / 3.0); 0.0..1.0; 1e-6 => 0.41768525592055004; 257);
+unit_test!(demo_function3_works = |x| (-x / 5000.0).exp() * (x / 1000.0).powf(-1.0 / 3.0); 0.0..10000.0; 1e-6 => 3679.81425836918; 257);
+unit_test!(demo_bad_function1_works = |x| (1.0 - x).powf(0.99); 0.0..1.0; 1e-6 => 0.50251256281407035);
+unit_test!(demo_bad_function2_works = |x| x.abs(); -1.0..1.0; 1e-6 => 1.0; 257);
+unit_test!(demo_bad_function3_works = |x| (0.5 - x.abs()).abs(); -1.0..1.0; 1e-6 => 0.5; 257);
+unit_test!(demo_circle = |x| ((1.0-(x.powi(2))).sqrt()).abs(); -1.0..1.0; 1e-6 => 1.5707963267949);
+unit_test!(demo_bad_circle = |x| ((1.0-(x.powi(2))).sqrt()-0.7).abs(); -1.0..1.0; 1e-4 => 0.420201353577392);

--- a/tests/double_exponential.rs
+++ b/tests/double_exponential.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 extern crate quadrature;
 
 use quadrature::double_exponential::integrate;

--- a/tests/double_exponential.rs
+++ b/tests/double_exponential.rs
@@ -1,0 +1,16 @@
+extern crate quadrature;
+
+use quadrature::double_exponential::integrate;
+
+#[macro_use]
+mod test_macro;
+
+unit_test!(trivial_function_works = |_| 0.5; -1.0..1.0; 1e-14);
+unit_test!(demo_function1_works = |x| (-x / 5.0).exp() * x.powf(-1.0 / 3.0); 0.0..10.0; 1e-6 => 3.6798142583691758);
+unit_test!(demo_function2_works = |x| (1.0 - x).powf(5.0) * x.powf(-1.0 / 3.0); 0.0..1.0; 1e-6 => 0.41768525592055004);
+unit_test!(demo_function3_works = |x| (-x / 5000.0).exp() * (x / 1000.0).powf(-1.0 / 3.0); 0.0..10000.0; 1e-6);
+unit_test!(demo_bad_function1_works = |x| (1.0 - x).powf(0.99); 0.0..1.0; 1e-6 => 0.50251256281407035);
+unit_test!(demo_bad_function2_works = |x| x.abs(); -1.0..1.0; 1e-6 => 1.0; 385);
+unit_test!(demo_bad_function3_works = |x| (0.5 - x.abs()).abs(); -1.0..1.0; 1e-6 => 0.5; 385);
+unit_test!(demo_circle = |x| ((1.0-(x.powi(2))).sqrt()).abs(); -1.0..1.0; 1e-6 => 1.5707963267949);
+unit_test!(demo_bad_circle = |x| ((1.0-(x.powi(2))).sqrt()-0.7).abs(); -1.0..1.0; 1e-4 => 0.420201353577392);

--- a/tests/test_macro.rs
+++ b/tests/test_macro.rs
@@ -1,3 +1,5 @@
+#![allow(unused_macros)]
+
 macro_rules! unit_test {
 ($name:ident = $inta:expr ; $lim:expr; $eps:expr => $out:expr; $max:expr) => (
     #[test]

--- a/tests/test_macro.rs
+++ b/tests/test_macro.rs
@@ -5,7 +5,7 @@ macro_rules! unit_test {
     #[test]
     fn $name() {
         let o = integrate($inta, $lim.start, $lim.end, $eps);
-        println!("\n{:#?}", o);
+        //println!("\n{:#?}", o);
         assert!(o.num_function_evaluations == $max,
                 "num_function_evaluations is not maxed out. evaluations: {:#?}, max: {:#?}",
                 o.num_function_evaluations,
@@ -20,7 +20,7 @@ macro_rules! unit_test {
     #[test]
     fn $name() {
         let o = integrate($inta, $lim.start, $lim.end, $eps);
-        println!("\n{:#?}", o);
+        //println!("\n{:#?}", o);
         assert!(o.error_estimate <= $eps,
                 "error_estimate larger then asked. estimate: {:#?}, asked: {:#?}",
                 o.error_estimate,
@@ -35,7 +35,7 @@ macro_rules! unit_test {
     #[test]
     fn $name() {
         let o = integrate($inta, $lim.start, $lim.end, $eps);
-        println!("\n{:#?}", o);
+        //println!("\n{:#?}", o);
         assert!(o.error_estimate <= $eps,
                 "error_estimate larger then asked. estimate: {:#?}, asked: {:#?}",
                 o.error_estimate,


### PR DESCRIPTION
* Unfortunately, some functionality from `core` had to be vendored, because it is not exposed by stable Rust. Hopefully this functionality will be in the `num_traits` crate version 0.2. This would allow deleting the newly added traits.
* The code taken from Rust is MPL/Apache licensed. I think the BSD license is more permissive? I would suggest to relicense this crate under MPL/Apache, to reduce friction with the Rust ecosystem. Alternatively, the `BasicFloat` could be implemented in a separate crate with a separate license, or we just wait until its functionality is provided by `num_traits`.